### PR TITLE
Allow upload to PyPI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,4 +15,5 @@ workflows:
   version: 2
   commit:
     jobs:
-      - build
+      - build:
+          context: circleci-user

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,18 @@
+version: 2.1
+
+executors:
+  docker-executor:
+    docker:
+      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:stitch-tap-tester
+
+jobs:
+  build:
+    executor: docker-executor
+    steps:
+      - run: echo 'CI done'
+
+workflows:
+  version: 2
+  commit:
+    jobs:
+      - build

--- a/setup.py
+++ b/setup.py
@@ -2,14 +2,10 @@ from setuptools import find_packages, setup
 
 requirements_file = "requirements.txt"
 
-with open("README.md") as f:
-    readme = f.read()
-
 setup(
     name="tap-dixa",
     version="0.1.0",
     description="Singer.io tap for extracting data from the Dixa API",
-    long_description=readme,
     author="Stitch",
     url="http://singer.io",
     classifiers=["Programming Language :: Python :: 3 :: Only"],


### PR DESCRIPTION
# Description of change
This PR fixes the tap's `setup.py` to be compliant with PyPI's rules for uploaded packages.

# Manual QA steps
## Commands produce failure
```sh
$ python setup.py sdist --dist-dir dist
$ twine upload ./dist/tap-dixa-0.1.0.tar.gz
```

## Error Message
```sh
HTTPError: 400 Bad Request from https://upload.pypi.org/legacy/
The description failed to render in the default format of reStructuredText. See https://pypi.org/help/#description-content-type for more information.
==============================
Error with twine upload
==============================
```

## Fix #1
Add `long_description_content_type = "text/markdown"` to `setup.py`.

To test that this worked, I build a new `dist` and pushed it to `test.pypi.org`
https://test.pypi.org/project/tap-dixa/0.1.0/

## Fix #2
Remove the `long_description` altogether.

To test that this worked, I build a new `dist` and pushed it to `test.pypi.org`
https://test.pypi.org/project/tap-dixa/0.1.1/

# Risks
 - Low. I peeked at https://pypi.org/project/tap-facebook/ and "Fix #2" aligns with how other taps look in pypi.org. So I went with this approach
 - Because I pushed to test.pypi.org, we don't have to cut a new version to upload
 
# Rollback steps
 - revert this branch
