### PR TITLE
config sourcing from client property for streams

### DIFF
--- a/tap_dixa/client.py
+++ b/tap_dixa/client.py
@@ -10,9 +10,10 @@ from tap_dixa.helpers import DixaURL
 class Client:
     """DixaClient Class for performing extraction from DixaApi"""
 
-    def __init__(self, api_token: str):
-        self._api_token = api_token
+    def __init__(self, config: dict):
+        self.config = config
         self._base_url = None
+        self._api_token = config["api_token"]
         self._session = requests.Session()
         self._headers = {}
 

--- a/tap_dixa/discover.py
+++ b/tap_dixa/discover.py
@@ -65,7 +65,7 @@ def discover(config: dict):
     if config:
         #Token Validation check before making any api request
         #params : mock parameter values are given for api token validation
-        Client(config["api_token"]).get(base_url=DixaURL.INTEGRATIONS.value,
+        Client(config).get(base_url=DixaURL.INTEGRATIONS.value,
                                         endpoint=ActivityLogs.endpoint,
                                         params={"created_after": datetime.today(),
                                         "created_before": datetime.now()})

--- a/tap_dixa/streams/abstracts.py
+++ b/tap_dixa/streams/abstracts.py
@@ -62,17 +62,18 @@ class IncrementalStream(BaseStream):
     interval = None
     old_replication_key = None
     
-    def get_bookmark(self,state :dict,config: dict) ->int:
+    def get_bookmark(self,state :dict) ->int:
         """
         A wrapper for singer.get_bookmark to deal with backward compatibility for bookmark values.
         :param state: A dictionary representing singer state
         :param config: A dictionary containing tap config data
         :return: epoch timestamp in the form of a int datatype
         """
+        config = self.client.config
         bookmark = singer.get_bookmark(state, self.tap_stream_id, self.replication_key, False)
         if not bookmark:
             # get previous bookmark value if the current dosent exists or default to start date
-            _ = singer.get_bookmark(state, self.tap_stream_id,self.old_replication_key, config["start_date"])   
+            _ = singer.get_bookmark(state, self.tap_stream_id,self.old_replication_key, config["start_date"])  
             return datetime_to_unix_ms(singer.utils.strptime_to_utc(_))
         return bookmark
 
@@ -106,7 +107,7 @@ class IncrementalStream(BaseStream):
 
         return Interval.MONTH.value
 
-    def sync(self, state: dict, stream_schema: dict, stream_metadata: dict, config: dict, transformer: singer.Transformer) -> dict:
+    def sync(self, state: dict, stream_schema: dict, stream_metadata: dict, transformer: singer.Transformer) -> dict:
         """
         The sync logic for an incremental stream.
 
@@ -117,9 +118,10 @@ class IncrementalStream(BaseStream):
         :param transformer: A singer Transformer object
         :return: State data in the form of a dictionary
         """
+        config = self.client.config
         if config.get("interval"):
             self.set_interval(config.get("interval"))
-        start_date_epoch = self.get_bookmark(state,config)
+        start_date_epoch = self.get_bookmark(state)
         # bookmark_datetime = singer.utils.strptime_to_utc(start_date)
         max_datetime = bookmark_datetime = start_date_epoch
 
@@ -150,7 +152,7 @@ class FullTableStream(BaseStream):
 
     replication_method = "FULL_TABLE"
 
-    def sync(self, state: dict, stream_schema: dict, stream_metadata: dict, config: dict, transformer: singer.Transformer) -> dict:
+    def sync(self, state: dict, stream_schema: dict, stream_metadata: dict,transformer: singer.Transformer) -> dict:
         """
         The sync logic for an full table stream.
 
@@ -162,7 +164,7 @@ class FullTableStream(BaseStream):
         :return: State data in the form of a dictionary
         """
         with singer.metrics.record_counter(self.tap_stream_id) as counter:
-            for record in self.get_records(config):
+            for record in self.get_records():
                 transformed_record = transformer.transform(record, stream_schema, stream_metadata)
                 singer.write_record(self.tap_stream_id, transformed_record)
                 counter.increment()

--- a/tap_dixa/sync.py
+++ b/tap_dixa/sync.py
@@ -9,7 +9,7 @@ LOGGER = singer.get_logger()
 def sync(config, state, catalog):
     """Sync data from tap source"""
 
-    client = Client(config.get("api_token"))
+    client = Client(config)
 
     with Transformer() as transformer:
         for stream in catalog.get_selected_streams(state):
@@ -25,7 +25,7 @@ def sync(config, state, catalog):
 
             singer.write_schema(tap_stream_id, stream_schema, stream_obj.key_properties, stream.replication_key)
 
-            state = stream_obj.sync(state, stream_schema, stream_metadata, config, transformer)
+            state = stream_obj.sync(state, stream_schema, stream_metadata,transformer)
             singer.write_state(state)
 
     state = singer.set_currently_syncing(state, None)


### PR DESCRIPTION
# Description of change
Changes the access of config values from keyword param to using it as an attribute of the client instance

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
