### PR TITLE
extend `activity_logs` schema

### DIFF
--- a/tap_dixa/schemas/activity_logs.json
+++ b/tap_dixa/schemas/activity_logs.json
@@ -164,6 +164,78 @@
                       "null",
                       "string"
                   ]
+              },
+              "avatarUrl": {
+                "type": [
+                    "null",
+                    "string"
+                ]
+              },
+              "subject" : {
+                "type": [
+                    "null",
+                    "string"
+                ]
+              },
+              "reason" : {
+                "type": [
+                    "null",
+                    "string"
+                ]
+              },
+              "tag" : {
+                "type": [
+                    "null",
+                    "string"
+                ]
+              },
+              "message" : {
+                "type": [
+                    "null",
+                    "string"
+                ]
+              },
+              "queueLabel" : {
+                "type": [
+                    "null",
+                    "string"
+                ]
+              },
+              "transferType" : {
+                "type": [
+                    "null",
+                    "string"
+                ]
+              },
+              "claimedFromType" : {
+                "type": [
+                    "null",
+                    "string"
+                ]
+              },
+              "claimedFromLabel" : {
+                "type": [
+                    "null",
+                    "string"
+                ]
+              },
+              "destinationId" : {
+                "type": [
+                    "null",
+                    "string"
+                ]
+              },
+              "destinationType" : {
+                "type": [
+                    "null",
+                    "string"
+                ]
+              },
+              "destinationLabel" : {
+                "type": [
+                    "null",
+                    "string"
+                ]
               }
           }
       }

--- a/tap_dixa/schemas/activity_logs.json
+++ b/tap_dixa/schemas/activity_logs.json
@@ -29,6 +29,12 @@
               "string"
           ]
       },
+      "_type": {
+        "type": [
+            "null",
+            "string"
+        ]
+    },
       "author": {
           "type": [
               "null",
@@ -67,6 +73,12 @@
               "object"
           ],
           "properties": {
+            "_type": {
+                "type": [
+                    "null",
+                    "string"
+                ]
+            },
               "agent": {
                   "type": [
                       "null",


### PR DESCRIPTION
# Description of change
Extends the `activity_logs` schema by adding missing fields provided by Dixa.

# Manual QA steps
 - ran tap manually
 - ran against `singer-check-tap` and `target-stitch --dry-run` with no issues
 - circle tests passing
 
# Risks
 - minimal, schema change only adds missing fields
 
# Rollback steps
 - revert this branch
