### PR TITLE
Custom fields schema

### DIFF
--- a/tap_dixa/schemas/conversations.json
+++ b/tap_dixa/schemas/conversations.json
@@ -274,6 +274,50 @@
         ]
       }
     },
+    "custom_fields": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": [
+          "null",
+          "object"
+        ],
+        "properties":{
+          "archived": {
+            "type": [
+              "null",
+              "boolean"
+            ]
+          },
+          "attribute_id": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "data_type": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "identifier": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "value": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        }
+      }
+    },
     "tags_info": {
       "type": [
         "null",


### PR DESCRIPTION
Add schema for custom fields

# Description of change
Added the custom_fields array of objects as [documented on the API docs](https://docs.dixa.io/openapi/exports-api/paths/~1v1~1conversation_export/get/)
<img width="642" alt="image" src="https://user-images.githubusercontent.com/1340823/203764866-8ff9ae1d-92ef-4bd1-b80b-20087839a9b8.png">

# Manual QA steps
 - Check for correct syntax
 
# Rollback steps
 - revert this branch
