### PR TITLE
TDL-23202 Bump urllib3 and requests for SCA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.3
+  * Moves urllib3 to a version that is not affected by GHSA-g4mx-q9vg-27p4
+  * Moves requests to a version that is not affected by CVE-2023-32681
+
 ## 1.0.2
   * Updated document links in README.md [#5] (https://github.com/singer-io/tap-dixa/pull/5)
   * Added custom_fields object in `conversations` stream's schema [#17] (https://github.com/singer-io/tap-dixa/pull/17)

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ requirements_file = "requirements.txt"
 
 setup(
     name="tap-dixa",
-    version="1.0.2",
+    version="1.0.3",
     description="Singer.io tap for extracting data from the Dixa API",
     author="Stitch",
     url="http://singer.io",

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
         "simplejson==3.11.1",
         "singer-python==5.12.1",
         "six==1.16.0",
-        "urllib3==1.26.6",
+        "urllib3==1.26.18",
     ],
     entry_points="""
     [console_scripts]

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
         "jsonschema==2.6.0",
         "python-dateutil==2.8.2",
         "pytz==2018.4",
-        "requests==2.26.0",
+        "requests==2.31.0",
         "simplejson==3.11.1",
         "singer-python==5.12.1",
         "six==1.16.0",


### PR DESCRIPTION
# Description of change
- Moves urllib3 to a version that is not affected by [GHSA-g4mx-q9vg-27p4](https://github.com/advisories/GHSA-g4mx-q9vg-27p4)
- Bumps requests to address [CVE-2023-32681](https://nvd.nist.gov/vuln/detail/CVE-2023-32681)

# Manual QA steps
 - N/A
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
