### PR TITLE
Bump idna and urllib3 for security updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Changelog
 
+# 1.0.10
+  * Bump idna and urllib3 for security updates [#35](https://github.com/singer-io/tap-dixa/pull/35)
+
 # 1.0.9
   * Bump requests to 2.33.0 for security updates [#34](https://github.com/singer-io/tap-dixa/pull/34)
-
 
 ## 1.0.8
   * Bump dependency versions for dependabot compliance [#32](https://github.com/singer-io/tap-dixa/pull/32)

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
         "certifi==2024.8.30",
         "charset-normalizer==2.0.4",
         "ciso8601==2.1.3",
-        "idna==3.10",
+        "idna==3.15",
         "jsonschema==2.6.0",
         "python-dateutil==2.8.2",
         "pytz==2018.4",
@@ -23,7 +23,7 @@ setup(
         "simplejson==3.11.1",
         "singer-python==5.13.2",
         "six==1.16.0",
-        "urllib3==2.6.3",
+        "urllib3==2.7.0",
     ],
     entry_points="""
     [console_scripts]


### PR DESCRIPTION
# Description of change
Bump idna=3.15 and urllib3=2.7.0 for security updates. bump version 1.0.10

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
